### PR TITLE
The cookie "tdrloc" value need encode otherwise they wouldn't receive right string

### DIFF
--- a/Disney/DisneyTokyoBase.js
+++ b/Disney/DisneyTokyoBase.js
@@ -50,7 +50,7 @@ function DisneylandTokyoBase(config) {
       // make request to disney server with our cookie
       self.FetchURL("http://info.tokyodisneyresort.jp/rt/s/realtime/" + self.park_id + "_attraction.html", {
         headers: {
-          'Cookie': 'tdrloc=' + cachedGeoCookie.cookie
+          'Cookie': 'tdrloc=' + encodeURIComponent(cachedGeoCookie.cookie)
         }
       }, function(err, body) {
         if (err) return self.Error("Error fetching ride times", err, callback);


### PR DESCRIPTION
In #16 mentioned, finally, I funded out what happen of the location check page always say that you need provide your location info.

If the value of "tdrloc" not encoded, sometimes( it would be all day long ) the API work incorrect when get waiting time.

