### PR TITLE
Use single network request function

### DIFF
--- a/Disney/DisneyTokyoBase.js
+++ b/Disney/DisneyTokyoBase.js
@@ -1,8 +1,6 @@
 // use the standard park base, as Tokyo setup is completely different to wdw
 var ParkBase = require("../parkBase");
 
-// request http lib
-var request = require("request");
 // parse cookies returned by server
 var cookie = require('cookie');
 // date/time parsing

--- a/Disney/DisneyTokyoBase.js
+++ b/Disney/DisneyTokyoBase.js
@@ -482,9 +482,7 @@ function DisneylandTokyoBase(config) {
       }
     }
 
-    self.Dbg("Fetching", reqObj);
-
-    request(reqObj, function(err, resp, body) {
+    self.MakeNetworkRequest(reqObj, function(err, resp, body) {
       if (err) return this.Error("API returned an error", err, callback);
 
       return callback(null, body, resp);

--- a/SeaWorld/SeaWorldBase.js
+++ b/SeaWorld/SeaWorldBase.js
@@ -35,7 +35,7 @@ function SeaworldBase(config) {
 
   // fetch a URL from the SeaWorld API
   this.GetAPIURL = function(page, callback) {
-    request({
+    var requestObject = {
       url: self.APIBase + self.park_id + "/" + page,
       method: "GET",
       headers: {
@@ -43,7 +43,9 @@ function SeaworldBase(config) {
         "User-Agent": self.useragent,
       },
       json: true,
-    }, function(err, resp, body) {
+    };
+
+    self.MakeNetworkRequest(requestObject, function(err, resp, body) {
       // if error, return error
       if (err) return self.Error("Error fetching " + page + " for SeaWorlds park " + park_id, err, callback);
 

--- a/SeaWorld/SeaWorldBase.js
+++ b/SeaWorld/SeaWorldBase.js
@@ -1,6 +1,5 @@
 var Park = require("../parkBase");
 
-var request = require("request");
 var moment = require("moment-timezone");
 
 // export the Seaworld base park object

--- a/SixFlags/SixFlagsBase.js
+++ b/SixFlags/SixFlagsBase.js
@@ -1,6 +1,5 @@
 var Park = require("../parkBase");
 
-var request = require("request");
 var moment = require("moment-timezone");
 
 // use one access token for all Six Flags parks
@@ -256,9 +255,7 @@ function SixFlagsBase(config) {
     // can also just set the request body directly
     if (options.body) requestBody.body = options.body;
 
-    self.Dbg("Fetching...", requestBody);
-
-    request(requestBody, function(err, resp, body) {
+    self.MakeNetworkRequest(requestBody, function(err, resp, body) {
       if (err) return self.Error("Error making Six Flags API request", err, callback);
 
       return callback(null, body);

--- a/Universal/UniversalBase.js
+++ b/Universal/UniversalBase.js
@@ -1,6 +1,5 @@
 var Park = require("../parkBase");
 
-var request = require("request");
 var moment = require("moment-timezone");
 require('moment-range');
 var crypto = require("crypto");
@@ -121,9 +120,7 @@ function UniversalBase(config) {
         }
       };
 
-      self.Dbg("Fetching...", requestObj);
-
-      request(requestObj, function(err, resp, body) {
+      self.MakeNetworkRequest(requestObj, function(err, resp, body) {
         if (err) return self.Error("Error fetching calendar page", err, callback);
 
         // parse returned HTML
@@ -288,9 +285,7 @@ function UniversalBase(config) {
       }
     }
 
-    self.Dbg("Fetching...", requestBody);
-
-    request(requestBody, function(err, resp, body) {
+    self.MakeNetworkRequest(requestBody, function(err, resp, body) {
       if (err) return self.Error("Error making Universal API request", err, callback);
 
       return callback(null, body);

--- a/Universal/UniversalJapanBase.js
+++ b/Universal/UniversalJapanBase.js
@@ -1,6 +1,5 @@
 var Park = require("../parkBase");
 
-var request = require("request");
 var moment = require("moment-timezone");
 
 module.exports = UniversalJapanBase;
@@ -74,9 +73,7 @@ function UniversalJapanBase(config) {
       }
     }
 
-    self.Dbg("Fetching...", requestBody);
-
-    request(requestBody, function(err, resp, body) {
+    self.MakeNetworkRequest(requestBody, function(err, resp, body) {
       if (err) return self.Error("Error making Universal Japan API request", err, callback);
 
       return callback(null, body);

--- a/debugView.js
+++ b/debugView.js
@@ -66,23 +66,3 @@ function WriteDebugFile() {
 process.on('exit', WriteDebugFile.bind());
 process.on('SIGINT', WriteDebugFile.bind());
 process.on('uncaughtException', WriteDebugFile.bind());
-
-if (!module.parent) {
-  RecordHTTPRequest("Test1", {
-    url: "fdssd"
-  }, {
-    test: true
-  });
-  RecordHTTPRequest("Test2", {
-    url: "fdssd"
-  }, {
-    test: true
-  });
-  StartSection("Test3");
-  RecordHTTPRequest("Test3.1", {}, {});
-  LogMessage("Does this work?", "I hope so...");
-  EndSection();
-  RecordHTTPRequest("Test4", {}, {});
-
-  console.log(JSON.stringify(debugAssets, null, 2));
-}

--- a/debugView.js
+++ b/debugView.js
@@ -1,0 +1,88 @@
+// Debug Viewer
+//  Usage:
+//   var debugger = require("./debugView");
+//   debugger.StartSection("my_section");
+//   debugger.RecordHTTPRequest("my_request", reqObj, responseData);
+//   debugger.EndSection();
+
+var fs = require("fs");
+var path = require("path");
+
+module.exports = {
+  StartSection: StartSection,
+  EndSection: EndSection,
+  RecordHTTPRequest: RecordHTTPRequest,
+  Log: LogMessage,
+}
+
+// list of debug assets we've stored
+var debugAssets = {
+  name: "Debug View",
+  children: [],
+};
+
+var sectionStack = [debugAssets];
+
+function StartSection(section_name) {
+  // create new section
+  sectionStack.push({
+    name: section_name,
+    children: [],
+  });
+
+  sectionStack[sectionStack.length - 2].children.push(sectionStack[sectionStack.length - 1]);
+}
+
+function EndSection() {
+  if (sectionStack.length > 1) sectionStack.pop();
+}
+
+function RecordHTTPRequest(name, data) {
+  sectionStack[sectionStack.length - 1].children.push({
+    name: name,
+    request: data,
+    datetime: Date.now(),
+  });
+}
+
+// log an arbitrary message to the debug view
+function LogMessage() {
+  sectionStack[sectionStack.length - 1].children.push({
+    name: "LOG",
+    message: Array.prototype.slice.call(arguments),
+    datetime: Date.now(),
+  });
+}
+
+function WriteDebugFile() {
+  if (process.env.DEBUGOUT) {
+    fs.writeFileSync(
+      path.join(__dirname, path.basename(process.env.DEBUGOUT, ".json") + ".json"),
+      JSON.stringify(debugAssets, null, 2)
+    );
+  }
+}
+
+process.on('exit', WriteDebugFile.bind());
+process.on('SIGINT', WriteDebugFile.bind());
+process.on('uncaughtException', WriteDebugFile.bind());
+
+if (!module.parent) {
+  RecordHTTPRequest("Test1", {
+    url: "fdssd"
+  }, {
+    test: true
+  });
+  RecordHTTPRequest("Test2", {
+    url: "fdssd"
+  }, {
+    test: true
+  });
+  StartSection("Test3");
+  RecordHTTPRequest("Test3.1", {}, {});
+  LogMessage("Does this work?", "I hope so...");
+  EndSection();
+  RecordHTTPRequest("Test4", {}, {});
+
+  console.log(JSON.stringify(debugAssets, null, 2));
+}

--- a/debugView.js
+++ b/debugView.js
@@ -13,7 +13,7 @@ module.exports = {
   EndSection: EndSection,
   RecordHTTPRequest: RecordHTTPRequest,
   Log: LogMessage,
-}
+};
 
 // list of debug assets we've stored
 var debugAssets = {

--- a/parkBase.js
+++ b/parkBase.js
@@ -160,7 +160,9 @@ function Park(config) {
     // make network request using request library
     request(requestObject, function(err, resp, body) {
       // debug log response
-      debugView.RecordHTTPRequest(requestObject.name || requestObject.url || "Unknown URL Request", resp);
+      if (process.env.NODE_DEBUG || self.debug || process.env.DEBUGOUT) {
+        debugView.RecordHTTPRequest(requestObject.name || requestObject.url || "Unknown URL Request", resp);
+      }
 
       // return request standard response
       return callback(err, resp, body);


### PR DESCRIPTION
Consolidate all the network request functions into a single function.

This allows us to debug all the network requests better, since we can now log them all in a readable format.