### PR TITLE
Fixed Tokyo Disney wrong waitime

### DIFF
--- a/Disney/DisneyTokyoBase.js
+++ b/Disney/DisneyTokyoBase.js
@@ -110,7 +110,7 @@ function DisneylandTokyoBase(config) {
 
       // get waiting time!
       // first, check for rides under maintenance
-      if (el.text().indexOf("運営・公演中止") >= 0) {
+      if (el.text().indexOf("運営・公演中止") >= 0 || el.text().indexOf("一時運営中止") >= 0 || el.text().indexOf("案内終了") >= 0) {
         // found the maintenance text, mark ride as inactive
         ride_data.waitTime = -1;
         ride_data.active = false;

--- a/Disney/DisneyTokyoBase.js
+++ b/Disney/DisneyTokyoBase.js
@@ -110,7 +110,13 @@ function DisneylandTokyoBase(config) {
 
       // get waiting time!
       // first, check for rides under maintenance
-      if (el.text().indexOf("運営・公演中止") >= 0 || el.text().indexOf("一時運営中止") >= 0 || el.text().indexOf("案内終了") >= 0) {
+      if (
+        // ride down for refurb/off-season (closed all day)
+        el.text().indexOf("運営・公演中止") >= 0
+        // ride unexpectedly closed
+        || el.text().indexOf("一時運営中止") >= 0
+        // "special type" closed, for non-standard attractions such as walking experiences or transport
+        || el.text().indexOf("案内終了") >= 0) {
         // found the maintenance text, mark ride as inactive
         ride_data.waitTime = -1;
         ride_data.active = false;


### PR DESCRIPTION
The stop status of ride has three type of Tokyo Disney. The following is the simple description.

1. 運営・公演中止 If you see this status, it's mean that ride was shutdown all day. It will be never turn to active today.

2. 一時運営中止 If the status show this word out, it's mean the ride is temporarily turn off for some reason, it will be open again for few minutes or few hours later(or maybe shutdown all day).

3. 案内終了 Special type ride, like gallery or transportation, this status mean that it's closed.

So, when those status showing up, waitime should be set to -1 and active flag should be false.